### PR TITLE
Don't overwrite timestamps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,6 @@ export default class Analytics {
 
     const data = {
       batch,
-      timestamp: new Date(),
       sentAt: new Date(),
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -182,7 +182,6 @@ describe('Analytics', () => {
         }
 
         assert.deepEqual(data.batch, [1, 2]);
-        assert(data.timestamp instanceof Date);
         assert(data.sentAt instanceof Date);
 
         return done();


### PR DESCRIPTION
As is, we are writing `timestamp` attributes in two places -- on the individual messages and on the payload of the batch Segment API call.

Segment takes the `timestamp` value from the batch API call and uses it to overwrite the `timestamp` value on the individual messages -- so we lose the timestamp when the event was created, and instead have two copies of the time we made the batch API call, `sentAt` and `timestamp`.

I propose we only write timestamps on the individual messages to prevent such overwrites.